### PR TITLE
Admin Grid Mass action Select / Unselect All issue #9610

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -274,7 +274,8 @@ class Extended extends \Magento\Backend\Block\Widget
 
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getAllIds();
+        $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);


### PR DESCRIPTION
Admin Grid Mass Action `Select All ` and `Unselect All` work only on `primary_key` of collection object no matter if we set other field as mass action filed using grid method `setMassactionIdField` other than `primar_key`

### Preconditions
1. Magento version 2.1.3


### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Found this issue while creating custom module where i need mass action id filed other than `primary_key` of collection. 

### Expected result
<!--- Tell us what should happen -->
1. It should `Select All` and `Unselect All`  on click of option
2. It should post `MassactionIdField`  on submit

### Actual result

1. Checkbox `checked` and `unchecked` not working on click of option
2. Always post  `primary_key` value of collection on submit


